### PR TITLE
fix: Add `javascriptreact` and `typescriptreact` language ids to missing places

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ export function load() {
 
 ## Supported File Types
 
-- JavaScript (`.js`)
-- TypeScript (`.ts`)
+- JavaScript (`.js`/`.jsx`)
+- TypeScript (`.ts`/`.tsx`)
 - Svelte (`.svelte`)
 
 ## Quick Setup

--- a/concepts/extension/activator.js
+++ b/concepts/extension/activator.js
@@ -275,7 +275,9 @@ class ExtensionActivator {
         const codeLensDisposable = vscode.languages.registerCodeLensProvider(
             [
                 { language: 'javascript', scheme: 'file' },
+                { language: 'javascriptreact', scheme: 'file' },
                 { language: 'typescript', scheme: 'file' },
+                { language: 'typescriptreact', scheme: 'file' },
                 { language: 'svelte', scheme: 'file' }
             ],
             codeLensProvider

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   ],
   "activationEvents": [
     "onLanguage:javascript",
+    "onLanguage:javascriptreact",
     "onLanguage:typescript",
+    "onLanguage:typescriptreact",
     "onLanguage:svelte"
   ],
   "main": "./extension.js",


### PR DESCRIPTION
`typescriptreact` and `javascriptreact` were missing from activationEvents and registerCodeLensProvider. Merge before resolving #4 