### PR TITLE
fix: Be able to navigate to translation value when value is empty string

### DIFF
--- a/concepts/sidebar/service.js
+++ b/concepts/sidebar/service.js
@@ -173,7 +173,7 @@ class SidebarService {
             
             // Use existing getTranslation method to get the processed value (handles both simple and complex)
             const translationValue = this.translationService.getTranslation(translations, key);
-            if (!translationValue) {
+            if (translationValue == null) {
                 vscode.window.showWarningMessage(`Key "${key}" not found in translation file`);
                 return;
             }


### PR DESCRIPTION
When creating a new translation using `>ElementaryWatson: Extract Text to Locale`, the default locale is populated with the selected string, and the other locales are assigned an empty string. In the ElementaryWatson left sidepanel in vs code, you can navigate to the individual translation keys/values that are present in the file you are viewing.

There is a problem in the current implementation.
```js
const translationValue = this.translationService.getTranslation(translations, key);
if (!translationValue) {
    vscode.window.showWarningMessage(`Key "${key}" not found in translation file`);
    return;
}
```
`!translationValue` also matches empty strings. So although the translation exists, the user cannot navigate to it. This PR fixes that by instead checking `if (translationValue == null)`