### PR TITLE
"Copy Translation" codelens action for better workflow

### DIFF
--- a/concepts/editor/codelens.js
+++ b/concepts/editor/codelens.js
@@ -39,13 +39,25 @@ class TranslationCodeLensProvider {
             const position = document.positionAt(result.end);
             const range = new vscode.Range(position, position);
             
-            const codeLens = new vscode.CodeLens(range, {
+            // InspectTranslation codelens
+            const inspectCodeLens = new vscode.CodeLens(range, {
                 title: `$(globe)  Inspect Translation`,
                 command: 'elementaryWatson.clickTranslationLabel',
                 arguments: [result.methodName, document.uri.fsPath]
             });
             
-            codeLenses.push(codeLens);
+            codeLenses.push(inspectCodeLens);
+
+            // CopyTranslation codelens
+            const copyCodeLens = new vscode.CodeLens(range, {
+                title: `$(copy)  Copy Translation`,
+                command: 'elementaryWatson.copyTranslation',
+                arguments: [result.translationValue,
+                            document.positionAt(result.start),
+                            document.positionAt(result.end)]
+            });
+
+            codeLenses.push(copyCodeLens);
         }
 
         return codeLenses;

--- a/concepts/extension/activator.js
+++ b/concepts/extension/activator.js
@@ -120,6 +120,9 @@ class ExtensionActivator {
         // Register sidebar commands
         this.registerSidebarCommands();
 
+        // Register copy translation command
+        this.registerCopyTranslationCommand();
+
         // Register translation label click command
         this.registerTranslationLabelClickCommand();
 
@@ -223,6 +226,45 @@ class ExtensionActivator {
         });
 
         this.disposables.push(extractTextCommand);
+    }
+
+    /**
+     * Register the copy translation command
+     */
+    registerCopyTranslationCommand() {
+        const copyTranslationCommand = vscode.commands.registerCommand('elementaryWatson.copyTranslation', async (translationValue, start, end) => {
+            // Open an input box and save input as newValue
+            const newValue = await vscode.window.showInputBox({
+                prompt: 'Edit Translation',
+                value: translationValue // Pre-fill with the current translation
+            });
+
+            // Get editor
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
+                vscode.window.showErrorMessage('No active text editor');
+                return;
+            }
+            // Check for supported document
+            if (!this.editorService.isSupportedDocument(editor.document)) {
+                vscode.window.showErrorMessage('Text extraction is only supported in JavaScript, TypeScript, and Svelte files');
+                return;
+            }
+
+            // Select the text corresponding to the range (start -> end)
+            const range = new vscode.Range(start, end);
+            editor.selection = new vscode.Selection(range.start, range.end);
+
+            // Filter only new values, for old value we dont need to do anything
+            if (newValue != translationValue) {
+                const success = await this.extractionService.createNewBinding(editor, newValue);
+                if (success) {
+                    vscode.window.showInformationMessage('New binding created successfully');
+                }
+            }
+        });
+
+        this.disposables.push(copyTranslationCommand);
     }
 
     /**

--- a/concepts/extraction/service.js
+++ b/concepts/extraction/service.js
@@ -105,6 +105,57 @@ class ExtractionService {
     }
 
     /**
+     * If newValue is not present in locale, then add new binding and replace selection with new key, else replace current key with existing key
+     * @param {vscode.TextEditor} editor The active text editor
+     * @param {string} newValue Text to be added as binding
+     * @returns {Promise<boolean>} True if creation was successful
+     */
+    async createNewBinding(editor, newValue) {
+        try {
+
+            // Process newValue if needed
+
+            const workspaceFolder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+            if (!workspaceFolder) {
+                vscode.window.showErrorMessage('No workspace folder found');
+                return false;
+            }
+
+            const workspacePath = workspaceFolder.uri.fsPath;
+
+            // Check if the exact text already exists in translations (using newValue), if so, replace the key in file
+            const existingKey = await this.findExistingTranslation(workspacePath, newValue);
+            if (existingKey) {
+                // Auto-interpolate with existing key without asking
+                return await this.replaceTextWithKey(editor, existingKey);
+            }
+
+            // Generate new key
+            const newKey = await this.generateUniqueKey(workspacePath);
+            if (!newKey) {
+                vscode.window.showErrorMessage('Failed to generate unique key');
+                return false;
+            }
+
+            // Add to locale files (using newValue)
+            const success = await this.addToLocaleFiles(workspacePath, newKey, newValue);
+            if (!success) {
+                vscode.window.showErrorMessage('Failed to update locale files');
+                return false;
+            }
+
+            // Replace current key with newKey
+            const keyCall = this.formatKeyCall(newKey, 'code');
+            return await this.replaceSelectedText(editor, keyCall);
+
+        } catch (error) {
+            console.error('Error during creation of new binding:', error);
+            vscode.window.showErrorMessage(`Failed to create new binding: ${error.message}`);
+            return false;
+        }
+    }
+
+    /**
      * Find if the exact text already exists in any translation (supports nested keys)
      * @param {string} workspacePath The workspace root path
      * @param {string} text The text to search for

--- a/concepts/extraction/service.js
+++ b/concepts/extraction/service.js
@@ -127,7 +127,8 @@ class ExtractionService {
             const existingKey = await this.findExistingTranslation(workspacePath, newValue);
             if (existingKey) {
                 // Auto-interpolate with existing key without asking
-                return await this.replaceTextWithKey(editor, existingKey);
+                const keyCall = this.formatKeyCall(existingKey, 'code');
+                return await this.replaceSelectedText(editor, keyCall);
             }
 
             // Generate new key


### PR DESCRIPTION
Added new codelens action "Copy Translation" for improved workflow.

New Workflow Process:

1. **User Interaction**:
When the user clicks the "Copy Translation" CodeLens action, a new input field is displayed.
2. **Existing Value**:
If the entered value has an existing translation binding, the corresponding key in the code is replaced with the correct one.
3. **New Value**:
If the value is not found in the existing translations, a new binding is created, and the code is updated to use the new randomly generated key.

Also, the user does not have to mark the key, but the one for which the user triggered the action is automatically marked and replaced.

<img width="1253" height="1097" alt="example" src="https://github.com/user-attachments/assets/d79a3abb-9780-4032-9447-56ff0bb8280f" />